### PR TITLE
Feat/Adding `:nth-child()` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.1
+
+- Added support for `:nth-child()` and `:first-child` selectors in `find` and `findAll` methods.
+- Supported expressions include integers (`2`), keywords (`odd`, `even`), and formulas (`2n+1`).
+
 ## 0.3.0
 
 - Added new **Modifying the Tree** methods: `newTag()`, `clear()`, `decompose()`, `wrap()`,

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -16,7 +16,6 @@ include: package:lints/recommended.yaml
 linter:
   rules:
     - public_member_api_docs
-    - package_api_docs
 
 # analyzer:
 #   exclude:

--- a/lib/src/interface/tree_searcher.dart
+++ b/lib/src/interface/tree_searcher.dart
@@ -62,6 +62,14 @@ abstract class ITreeSearcher {
   /// will be ignored. If such selector is not implemented this method
   /// will throw [UnimplementedError].
   ///
+  /// **Supported pseudo-classes**: `:nth-child()` (supports integers, keywords like `odd`/`even`, and formulas like `2n+1`) and `:first-child`.
+  ///
+  /// Examples:
+  /// ```dart
+  /// bs.find(selector: 'div > p:nth-child(2)'); // Find 2nd paragraph in a div
+  /// bs.findAll(selector: 'li:nth-child(odd)'); // Find all odd list items
+  /// ```
+  ///
   /// Use `true` as an attribute value to search any value.
   /// {@endtemplate}
   List<Bs4Element> findAll(

--- a/lib/src/shared.dart
+++ b/lib/src/shared.dart
@@ -6,6 +6,10 @@ import 'package:html/dom.dart';
 import 'interface/interface.dart';
 import 'tags.dart';
 
+final _firstChildRegex = RegExp(r':first-child\b');
+final _nthChildRegex = RegExp(r':nth-child\((.*?)\)');
+final _nthChildFormulaRegex = RegExp(r'^\s*([-+]?\d*)?n\s*([-+]\s*\d+)?\s*$');
+
 class Shared extends Tags implements ITreeSearcher, IOutput {
   @override
   Bs4Element? findFirstAny() =>
@@ -23,6 +27,10 @@ class Shared extends Tags implements ITreeSearcher, IOutput {
     String? selector,
   }) {
     if (selector != null) {
+      if (selector.contains(':nth-child') ||
+          selector.contains(':first-child')) {
+        return findAll('', selector: selector).firstOrNull;
+      }
       return ((element ?? doc).querySelector(selector) as Element?)?.bs4;
     }
     if (id == null && class_ == null && regex == null && string == null) {
@@ -61,9 +69,50 @@ class Shared extends Tags implements ITreeSearcher, IOutput {
     assert(limit == null || limit >= 0);
 
     if (selector != null) {
-      return ((element ?? doc).querySelectorAll(selector) as List<Element>)
-          .map((e) => e.bs4)
-          .toList();
+      // Handle :nth-child / :first-child if present
+      String cleanSelector = selector;
+      var hasFirstChild = false;
+      var nthChildExpression = '';
+
+      if (_firstChildRegex.hasMatch(selector)) {
+        hasFirstChild = true;
+        cleanSelector = cleanSelector.replaceAll(_firstChildRegex, '');
+      } else if (_nthChildRegex.hasMatch(selector)) {
+        final match = _nthChildRegex.firstMatch(selector);
+        if (match != null) {
+          nthChildExpression = match.group(1) ?? '';
+          cleanSelector = cleanSelector.replaceAll(_nthChildRegex, '');
+        }
+      }
+
+      // If selector becomes empty (matches *), use *
+      if (cleanSelector.trim().isEmpty) {
+        cleanSelector = '*';
+      }
+
+      final elements =
+          ((element ?? doc).querySelectorAll(cleanSelector) as List<Element>)
+              .map((e) => e.bs4)
+              .toList();
+
+      if (hasFirstChild) {
+        return elements.where((e) {
+          final parent = e.element?.parentNode;
+          if (parent == null) return false;
+          // :first-child means it is the first ELEMENT child
+          // package:html parent.children returns elements only
+          final children = parent.children;
+          return children.isNotEmpty && children.first == e.element;
+        }).toList();
+      }
+
+      if (nthChildExpression.isNotEmpty) {
+        return elements.where((e) {
+          return _isNthChildMatch(e, nthChildExpression);
+        }).toList();
+      }
+
+      return elements;
     }
     bool anyTag = _isAnyTag(name);
     bool validTag = _isValidTag(name);
@@ -683,4 +732,65 @@ Iterable<_TagDataExtractor> _recursiveNodeExtractorSearch(
   for (final e in node.nodes) {
     yield* _recursiveNodeExtractorSearch(e, indentation: indentation ?? 1);
   }
+}
+
+bool _isNthChildMatch(Bs4Element bs4, String expression) {
+  expression = expression.trim();
+  final parent = bs4.element?.parentNode;
+  if (parent == null) return false;
+
+  final children = parent.children;
+  final index = children.indexOf(bs4.element!) + 1; // 1-based index
+
+  if (expression == 'odd') {
+    return index % 2 == 1;
+  }
+  if (expression == 'even') {
+    return index % 2 == 0;
+  }
+
+  // Handle integers
+  final nIndex = int.tryParse(expression);
+  if (nIndex != null) {
+    return index == nIndex;
+  }
+
+  // Handle formula An+B
+  // 2n+1, 3n+0, -n+3, etc.
+  final match = _nthChildFormulaRegex.firstMatch(expression);
+  if (match != null) {
+    var aStr = match.group(1);
+    var bStr = match.group(2)?.replaceAll(' ', '');
+
+    int a;
+    if (aStr == null || aStr.isEmpty) {
+      a = 1;
+    } else if (aStr == '-') {
+      a = -1;
+    } else if (aStr == '+') {
+      a = 1;
+    } else {
+      a = int.parse(aStr);
+    }
+
+    int b = (bStr == null || bStr.isEmpty) ? 0 : int.parse(bStr);
+
+    // index = a * n + b
+    // index - b = a * n
+    // (index - b) % a == 0 and n >= 0
+
+    if (a == 0) {
+      return index == b;
+    }
+
+    // n must be non-negative integer
+    // n = (index - b) / a
+    if ((index - b) % a == 0) {
+      final n = (index - b) ~/ a;
+      return n >= 0;
+    }
+    return false;
+  }
+
+  return false;
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,351 +5,393 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://pub.dartlang.org"
+      sha256: "5b7468c326d2f8a4f630056404ca0d291ade42918f4a3c6233618e724f39da8e"
+      url: "https://pub.dev"
     source: hosted
-    version: "41.0.0"
+    version: "92.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      url: "https://pub.dartlang.org"
+      sha256: "70e4b1ef8003c64793a9e268a551a82869a8a96f39deb73dea28084b0e8bf75e"
+      url: "https://pub.dev"
     source: hosted
-    version: "4.2.0"
+    version: "9.0.0"
   args:
     dependency: transitive
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.7.0"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.7.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "5bbf32bc9e518d41ec49718e2931cd4527292c9b0c6d2dffcf7fe6b9a8a8cf72"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
-      url: "https://pub.dartlang.org"
+      sha256: fb98c0f6d12c920a02ee2d998da788bca066ca5f148492b7085ee23372b12306
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  cli_config:
+    dependency: transitive
+    description:
+      name: cli_config
+      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.19.1"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.dartlang.org"
+      sha256: f08428ad63615f96a27e34221c65e1a451439b5f26030f78d790f461c686d65d
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      url: "https://pub.dartlang.org"
+      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.15.0"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: cf75650c66c0316274e21d7c43d3dea246273af5955bd94e8184837cd577575c
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
   csslib:
     dependency: transitive
     description:
       name: csslib
-      url: "https://pub.dartlang.org"
+      sha256: "09bad715f418841f976c77db72d5398dc1253c21fb9c0c7f0b0b985860b2d58e"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.17.0"
+    version: "1.0.2"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
     source: hosted
-    version: "6.1.2"
+    version: "7.0.1"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
-      url: "https://pub.dartlang.org"
+      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "4.0.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      url: "https://pub.dartlang.org"
+      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.3"
   html:
     dependency: "direct main"
     description:
       name: html
-      url: "https://pub.dartlang.org"
+      sha256: "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.15.0"
+    version: "0.15.6"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      url: "https://pub.dartlang.org"
+      sha256: bfb651625e251a88804ad6d596af01ea903544757906addcb2dcdf088b5ea185
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      sha256: e362d639ba3bc07d5a71faebb98cde68c05bfbcfbbb444b60b6f60bb67719185
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
   io:
     dependency: transitive
     description:
       name: io
-      url: "https://pub.dartlang.org"
+      sha256: "15a5436d2a02dc60e6dc2fb5d7dfaac08b7b137cff3d4bf3158d38ecab656b69"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.6.3"
   lints:
     dependency: "direct dev"
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: a5e2b223cb7c9c8efdc663ef484fdd95bb243bff242ef5b13e26883547fce9a0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "6.0.0"
   logging:
     dependency: transitive
     description:
       name: logging
-      url: "https://pub.dartlang.org"
+      sha256: "0520a4826042a8a5d09ddd4755623a50d37ee536d79a70452aff8c8ad7bb6c27"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.18"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://pub.dartlang.org"
+      sha256: a7a98ea7f366e2cc9d2b20873815aebec5e2bc124fe0da9d3f7f59b0625ea180
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
-      url: "https://pub.dartlang.org"
+      sha256: "8ebdbaa3b96d5285d068f80772390d27c21e1fa10fb2df6627b1b9415043608d"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://pub.dartlang.org"
+      sha256: "20e7154d701fedaeb219dad732815ecb66677667871127998a9a6581c2aba4ba"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.11.1"
+    version: "1.9.1"
   pool:
     dependency: transitive
     description:
       name: pool
-      url: "https://pub.dartlang.org"
+      sha256: "05955e3de2683e1746222efd14b775df7131139e07695dc8e24650f6b4204504"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      url: "https://pub.dartlang.org"
+      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.2.0"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      url: "https://pub.dartlang.org"
+      sha256: "26d22c68cf9c349fb1adb4a830da3e014cb5f7ed9cc57f721d9d9e20cf8d6de5"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.4"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      url: "https://pub.dartlang.org"
+      sha256: e0b44ebddec91e70a713e13adf93c1b2100821303b86a18e1ef1d082bd8bd9b8
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      url: "https://pub.dartlang.org"
+      sha256: "8584c0aa0f5756a61519b1a2fc2cd22ddbc518e9396bd33ebf06b9836bb23d13"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      url: "https://pub.dartlang.org"
+      sha256: fd84910bf7d58db109082edf7326b75322b8f186162028482f53dc892f00332d
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "8c463326277f68a628abab20580047b419c2ff66756fd0affd451f73f9508c11"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      url: "https://pub.dartlang.org"
+      sha256: "52de2200bb098de739794c82d09c41ac27b2e42fd7e23cce7b9c74bf653c7296"
+      url: "https://pub.dev"
     source: hosted
     version: "0.10.10"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: d5f89a9e52b36240a80282b3dc0667dd36e53459717bb17b8fb102d30496606a
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: f8d9f247e2f9f90e32d1495ff32dac7e4ae34ffa7194c5ff8fcc0fd0e52df774
+      url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: db47e4797198ee601990820437179bb90219f918962318d494ada2b4b11e6f6d
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a88162591b02c1f3a3db3af8ce1ea2b374bd75a7bb8d5e353bcfbdc79d719830
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   test:
     dependency: "direct dev"
     description:
       name: test
-      url: "https://pub.dartlang.org"
+      sha256: "77cc98ea27006c84e71a7356cf3daf9ddbde2d91d84f77dbfe64cf0e4d9611ae"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.21.3"
+    version: "1.28.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.11"
+    version: "0.7.8"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      url: "https://pub.dartlang.org"
+      sha256: f1072617a6657e5fc09662e721307f7fb009b4ed89b19f47175d11d5254a62d4
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.15"
+    version: "0.6.14"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: "53bdf7e979cfbf3e28987552fd72f637e63f3c8724c9e56d9246942dc2fa36ee"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      url: "https://pub.dartlang.org"
+      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
+      url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "15.0.2"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://pub.dartlang.org"
+      sha256: f52385d4f73589977c80797e60fe51014f7f2b957b5e9a62c3f6ada439889249
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.2.0"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      url: "https://pub.dartlang.org"
+      sha256: "0c2ada1b1aeb2ad031ca81872add6be049b8cb479262c6ad3c4b0f9c24eaab2f"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      url: "https://pub.dartlang.org"
+      sha256: "5adb6ab8ed14e22bb907aae7338f0c206ea21e7a27004e97664b16c120306f00"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.3"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=3.9.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: beautiful_soup_dart
 description: Dart native package inspired by Beautiful Soup 4 Python library. Provides easy ways of navigating, searching, and modifying the HTML tree.
 homepage: https://github.com/mzdm/beautiful_soup
-version: 0.3.0
+version: 0.3.1
 
 environment:
   sdk: '>=3.2.0 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,11 +4,11 @@ homepage: https://github.com/mzdm/beautiful_soup
 version: 0.3.0
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 
 dependencies:
-  html: ^0.15.0
+  html: ^0.15.6
 
 dev_dependencies:
-  lints: ^2.0.0
-  test: ^1.21.3
+  lints: ^6.0.0
+  test: ^1.28.0

--- a/test/nth_child_test.dart
+++ b/test/nth_child_test.dart
@@ -1,0 +1,49 @@
+import 'package:beautiful_soup_dart/beautiful_soup.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('nth-child check', () {
+    final html = '''
+<div>
+  <p>1</p>
+  <p>2</p>
+  <p>3</p>
+  <p>4</p>
+  <p>5</p>
+</div>
+''';
+    final bs = BeautifulSoup(html);
+
+    // :nth-child(n)
+    final p2 = bs.find('', selector: 'p:nth-child(2)');
+    expect(p2?.string, '2', reason: 'Should find 2nd paragraph');
+
+    // :nth-child( n ) with spaces
+    final p2spaces = bs.find('', selector: 'p:nth-child( 2 )');
+    expect(p2spaces?.string, '2',
+        reason: 'Should find 2nd paragraph even with spaces');
+
+    // :first-child
+    final p1 = bs.find('', selector: 'p:first-child');
+    expect(p1?.string, '1', reason: 'Should find 1st paragraph');
+
+    // :nth-child(odd) -> 1, 3, 5
+    final odds = bs.findAll('', selector: 'p:nth-child(odd)');
+    expect(odds.length, 3, reason: 'Should find 3 odd paragraphs');
+    expect(odds.map((e) => e.string).toList(), ['1', '3', '5']);
+
+    // :nth-child(even) -> 2, 4
+    final evens = bs.findAll('', selector: 'p:nth-child(even)');
+    expect(evens.length, 2, reason: 'Should find 2 even paragraphs');
+    expect(evens.map((e) => e.string).toList(), ['2', '4']);
+
+    // :nth-child(2n+1) -> 1, 3, 5
+    final formula = bs.findAll('', selector: 'p:nth-child(2n+1)');
+    expect(formula.length, 3);
+    expect(formula.map((e) => e.string).toList(), ['1', '3', '5']);
+
+    // complex selector: div > p:nth-child(2)
+    final complex = bs.find('', selector: 'div > p:nth-child(2)');
+    expect(complex?.string, '2');
+  });
+}


### PR DESCRIPTION
This PR adds support for the ` :nth-child()` and `:first-child` CSS pseudo-classes to the `find` and `findAll` methods. 
This enables more precise element selection based on sibling position, addressing a limitation in the underlying html package.

this PR support the following pseudo-classes: **`:nth-child()` (supports integers, keywords like `odd`/`even`, and formulas like `2n+1`) and `:first-child`**

Examples:
```dart
 bs.find(selector: 'div > p:nth-child(2)'); // Find 2nd paragraph in a div
 bs.findAll(selector: 'li:nth-child(odd)'); // Find all odd list items
```

Verification
- [x] New test created at `test/nth_child_test.dart` that test all the feature and successfully passing.
- [x] All Now existing 182 tests pass.
